### PR TITLE
Bugfix/remote-media-storage

### DIFF
--- a/Core/FieldType/RemoteMedia/RemoteMediaStorage.php
+++ b/Core/FieldType/RemoteMedia/RemoteMediaStorage.php
@@ -31,19 +31,22 @@ class RemoteMediaStorage extends GatewayBasedStorage
 
     /**
      * Constructor.
-
      * @param \eZ\Publish\API\Repository\ContentService $contentService
      * @param \Netgen\Bundle\RemoteMediaBundle\RemoteMedia\RemoteMediaProvider $provider
      * @param \eZ\Publish\API\Repository\FieldTypeService $fieldTypeService
+     * @param array $gateways
      */
     public function __construct(
         ContentService $contentService,
         RemoteMediaProvider $provider,
-        FieldTypeService $fieldTypeService
+        FieldTypeService $fieldTypeService,
+        array $gateways = array()
     ) {
         $this->contentService = $contentService;
         $this->provider = $provider;
         $this->fieldTypeService = $fieldTypeService;
+
+        parent::__construct($gateways);
     }
 
     public function setDeleteUnused($deleteUnused = false)

--- a/Core/FieldType/RemoteMedia/RemoteMediaStorage.php
+++ b/Core/FieldType/RemoteMedia/RemoteMediaStorage.php
@@ -153,7 +153,7 @@ class RemoteMediaStorage extends GatewayBasedStorage
 
             foreach ($resourceIdsToDelete as $resourceId) {
                 // check if resource_id is used anywhere else
-                if (!$gateway->remoteResourceConnected($resourceId)) {
+                if (!$gateway->remoteResourceConnected($resourceId, $this->provider->getIdentifier())) {
                     // delete from remote provider
                     $this->provider->deleteResource($resourceId);
                 }


### PR DESCRIPTION
RemoteMediaStorage class extends GatewayBasedStorage class and overrides it's constructor, but it was missing a call to parent constructor, which expects an array of gateways.

Also, call to remoteResourceConnected() function was missing a second parameter (provider identifier).