### PR TITLE
Use value instead of resourceId for video thumbnail and tag

### DIFF
--- a/ezpublish_legacy/ngremotemedia/template_operator/ngremotemediaoperator.php
+++ b/ezpublish_legacy/ngremotemedia/template_operator/ngremotemediaoperator.php
@@ -163,7 +163,7 @@ class NgRemoteMediaOperator
         $container = ezpKernel::instance()->getServiceContainer();
         $provider = $container->get( 'netgen_remote_media.provider' );
 
-        return $provider->getVideoThumbnail($value->resourceId);
+        return $provider->getVideoThumbnail($value);
     }
 
     function getVideoTag($value, $availableFormats, $format)
@@ -171,6 +171,6 @@ class NgRemoteMediaOperator
         $container = ezpKernel::instance()->getServiceContainer();
         $provider = $container->get( 'netgen_remote_media.provider' );
 
-        return $provider->generateVideoTag($value->resourceId, $format, $availableFormats);
+        return $provider->generateVideoTag($value, $format, $availableFormats);
     }
 }


### PR DESCRIPTION
When generating video thumbnail and tag, wrong parameter is being used in legacy extension. The RemoteMedia provider expects Value, while resourceId (string) is being used in the extension.