### PR TITLE
Implemented fromString and toString inteface for legacy ngremotemedia…

### DIFF
--- a/ezpublish_legacy/ngremotemedia/datatypes/ngremotemedia/ngremotemediatype.php
+++ b/ezpublish_legacy/ngremotemedia/datatypes/ngremotemedia/ngremotemediatype.php
@@ -261,22 +261,17 @@ class NgRemoteMediaType extends eZDataType
 
     function fromString($contentObjectAttribute, $string)
     {
-        $id = $string;
-        if(empty($string)){
-            $id = 'removed';
-        }
-
         $container = ezpKernel::instance()->getServiceContainer();
         $provider = $container->get( 'netgen_remote_media.provider' );
 
         $value = $contentObjectAttribute->Content();
         $updatedValue = new Value();
 
-        if ($id !== 'removed') {
+        if (!empty($string)) {
             $updatedValue = $value;
 
-            if(empty($updatedValue->resourceId) || $updatedValue->resourceId !== $id){
-                $updatedValue->resourceId = $id;
+            if(empty($updatedValue->resourceId) || $updatedValue->resourceId !== $string){
+                $updatedValue->resourceId = $string;
             }
         }
         $contentObjectAttribute->setAttribute(self::FIELD_VALUE, json_encode($updatedValue));

--- a/ezpublish_legacy/ngremotemedia/datatypes/ngremotemedia/ngremotemediatype.php
+++ b/ezpublish_legacy/ngremotemedia/datatypes/ngremotemedia/ngremotemediatype.php
@@ -249,6 +249,41 @@ class NgRemoteMediaType extends eZDataType
 
         return $value;
     }
+
+    function toString($contentObjectAttribute)
+    {
+        if(!$this->hasObjectAttributeContent($contentObjectAttribute)){
+            return '';
+        }
+        $value = $this->objectAttributeContent($contentObjectAttribute);
+        return $value->resourceId;
+    }
+
+    function fromString($contentObjectAttribute, $string)
+    {
+        $id = $string;
+        if(empty($string)){
+            $id = 'removed';
+        }
+
+        $container = ezpKernel::instance()->getServiceContainer();
+        $provider = $container->get( 'netgen_remote_media.provider' );
+
+        $value = $contentObjectAttribute->Content();
+        $updatedValue = new Value();
+
+        if ($id !== 'removed') {
+            $updatedValue = $value;
+
+            if(empty($updatedValue->resourceId) || $updatedValue->resourceId !== $id){
+                $updatedValue->resourceId = $id;
+            }
+        }
+        $contentObjectAttribute->setAttribute(self::FIELD_VALUE, json_encode($updatedValue));
+        $this->saveExternalData($contentObjectAttribute, $updatedValue, $provider);
+
+        return true;
+    }
 }
 
 eZDataType::register(


### PR DESCRIPTION
… datatype

This pull requests provides fromString and toString methods for the legacy datatype.

fromString() method accepts either and empty string, 'removed' or valid resource ID.
toString() method returns either an empty string, or a valid resource ID from the attribute.