### PR TITLE
Remove adding of controls by default.

### DIFF
--- a/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
+++ b/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
@@ -403,7 +403,6 @@ class CloudinaryProvider extends RemoteMediaProvider
     public function generateVideoTag(Value $value, $contentTypeIdentifier, $variationName = '')
     {
         $finalOptions = array(
-            'controls' => true,
             'fallback_content' => 'Your browser does not support HTML5 video tags'
         );
 

--- a/Tests/RemoteMedia/Provider/Cloudinary/CloudinaryProviderTest.php
+++ b/Tests/RemoteMedia/Provider/Cloudinary/CloudinaryProviderTest.php
@@ -439,7 +439,6 @@ class CloudinaryProviderTest extends TestCase
     public function testGetVideoTag()
     {
         $options = array(
-            'controls' => true,
             'fallback_content' => 'Your browser does not support HTML5 video tags'
         );
 
@@ -457,7 +456,6 @@ class CloudinaryProviderTest extends TestCase
     public function testGetVideoTagWithProvidedVariation()
     {
         $options = array(
-            'controls' => true,
             'fallback_content' => 'Your browser does not support HTML5 video tags'
         );
 


### PR DESCRIPTION
With adding controls by default we effectively disable users from
having video tag without controls, as controls attribute is not
boolean, but either present or not.