### PR TITLE
Bugfix/upload format bc

### DIFF
--- a/Core/FieldType/RemoteMedia/RemoteMediaStorage.php
+++ b/Core/FieldType/RemoteMedia/RemoteMediaStorage.php
@@ -9,6 +9,7 @@ use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\API\Repository\ContentService;
 use Netgen\Bundle\RemoteMediaBundle\RemoteMedia\RemoteMediaProvider;
+use Netgen\Bundle\RemoteMediaBundle\RemoteMedia\UploadFile;
 
 class RemoteMediaStorage extends GatewayBasedStorage
 {
@@ -79,16 +80,11 @@ class RemoteMediaStorage extends GatewayBasedStorage
                 $versionInfo->versionNo
             );
         } else if (is_array($data) && !empty($data)) {
-            $fileUri = $data['input_uri'];
-            $id = pathinfo($fileUri, PATHINFO_FILENAME);
-
             $options['alt_text'] = $data['alt_text'];
             $options['caption'] = $data['caption'];
-            $value = $this->provider->upload(
-                $fileUri,
-                $id,
-                $options
-            );
+
+            $uploadFile = UploadFile::fromUri($data['input_uri']);
+            $value = $this->provider->upload($uploadFile, $options);
 
             $value->variations = $data['variations'];
 

--- a/RemoteMedia/RemoteMediaProvider.php
+++ b/RemoteMedia/RemoteMediaProvider.php
@@ -53,13 +53,12 @@ abstract class RemoteMediaProvider
     /**
      * Uploads the local resource to remote storage and builds the Value from the response.
      *
-     * @param string $fileUri
-     * @param string $fileName
+     * @param UploadFile $uploadFile
      * @param array $options
      *
      * @return Value
      */
-    abstract public function upload($fileUri, $fileName, $options = array());
+    abstract public function upload(UploadFile $uploadFile, $options = array());
 
     /**
      * Gets the remote media Variation.

--- a/RemoteMedia/UploadFile.php
+++ b/RemoteMedia/UploadFile.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Netgen\Bundle\RemoteMediaBundle\RemoteMedia;
+
+use \eZHTTPFile;
+
+class UploadFile
+{
+    private $uri;
+
+    private $originalFilename;
+
+    private $originalExtension;
+
+    private function __construct() {}
+
+    /**
+     * Constructs UploadFile from given uri.
+     *
+     * @param $uri
+     *
+     * @return UploadFile
+     */
+    public static function fromUri($uri)
+    {
+        $uploadFile = new UploadFile;
+
+        $uploadFile->uri = $uri;
+        $uploadFile->originalFilename = pathinfo($uri, PATHINFO_FILENAME);
+        $uploadFile->originalExtension = pathinfo($uri, PATHINFO_EXTENSION);
+
+        return $uploadFile;
+    }
+
+    /**
+     * Constructs UploadFile from given eZHTTPFile (usually uploaded through the legacy admin).
+     *
+     * @param eZHTTPFile $file
+     *
+     * @return UploadFile
+     */
+    public static function fromZHTTPFile(eZHTTPFile $file)
+    {
+        $uploadFile = new UploadFile;
+
+        $uploadFile->uri = $file->Filename;
+        $uploadFile->originalFilename = pathinfo($file->OriginalFilename, PATHINFO_FILENAME);
+        $uploadFile->originalExtension = pathinfo($file->OriginalFilename, PATHINFO_EXTENSION);
+
+        return $uploadFile;
+    }
+
+    /**
+     * @return string
+     */
+    public function uri()
+    {
+        return $this->uri;
+    }
+
+    /**
+     * @return string
+     */
+    public function originalFilename()
+    {
+        return $this->originalFilename;
+    }
+
+    /**
+     * @return string
+     */
+    public function originalExtension()
+    {
+        return $this->originalExtension;
+    }
+}

--- a/RemoteMedia/UploadFile.php
+++ b/RemoteMedia/UploadFile.php
@@ -3,6 +3,7 @@
 namespace Netgen\Bundle\RemoteMediaBundle\RemoteMedia;
 
 use \eZHTTPFile;
+use eZ\Publish\Core\FieldType\Image\Value;
 
 class UploadFile
 {
@@ -46,6 +47,25 @@ class UploadFile
         $uploadFile->uri = $file->Filename;
         $uploadFile->originalFilename = pathinfo($file->OriginalFilename, PATHINFO_FILENAME);
         $uploadFile->originalExtension = pathinfo($file->OriginalFilename, PATHINFO_EXTENSION);
+
+        return $uploadFile;
+    }
+
+    /**
+     * Constructs UploadFile from given eZImage field Value.
+     *
+     * @param Value $value
+     * @param $webRoot
+     *
+     * @return UploadFile
+     */
+    public static function fromEzImageValue(Value $value, $webRoot)
+    {
+        $uploadFile = new UploadFile;
+
+        $uploadFile->uri = $webRoot.$value->uri;
+        $uploadFile->originalFilename = pathinfo($value->fileName, PATHINFO_FILENAME);
+        $uploadFile->originalExtension = pathinfo($value->fileName, PATHINFO_EXTENSION);
 
         return $uploadFile;
     }

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/ezpublish_legacy/ngremotemedia/modules/ngremotemedia/simple_upload.php
+++ b/ezpublish_legacy/ngremotemedia/modules/ngremotemedia/simple_upload.php
@@ -1,5 +1,7 @@
 <?php
 
+use Netgen\Bundle\RemoteMediaBundle\RemoteMedia\UploadFile;
+
 $http = eZHTTPTool::instance();
 
 $file = eZHTTPFile::fetch( 'file' );
@@ -23,10 +25,8 @@ if (empty($file) || empty($fieldId) || empty($contentId) || empty($contentVersio
 $container = ezpKernel::instance()->getServiceContainer();
 $provider = $container->get( 'netgen_remote_media.provider' );
 
-$value = $provider->upload(
-    $file->Filename,
-    pathinfo($file->OriginalFilename, PATHINFO_FILENAME)
-);
+$uploadFile = UploadFile::fromZHTTPFile($file);
+$value = $provider->upload($uploadFile);
 
 $responseData = array(
     'media' => !empty($value->resourceId) ? $value : false,

--- a/ezpublish_legacy/ngremotemedia/modules/ngremotemedia/upload.php
+++ b/ezpublish_legacy/ngremotemedia/modules/ngremotemedia/upload.php
@@ -1,5 +1,7 @@
 <?php
 
+use Netgen\Bundle\RemoteMediaBundle\RemoteMedia\UploadFile;
+
 $http = eZHTTPTool::instance();
 
 $contentId = $Params['contentobject_id'];
@@ -29,7 +31,8 @@ if ($folder !== 'all') {
     $options['folder'] = $folder;
 }
 
-$value = $provider->upload($file->Filename, pathinfo($file->OriginalFilename, PATHINFO_FILENAME), $options);
+$uploadFile = UploadFile::fromZHTTPFile($file);
+$value = $provider->upload($uploadFile, $options);
 
 $attribute = eZContentObjectAttribute::fetch($fieldId, $contentVersionId);
 $attribute->setAttribute('data_text', json_encode($value));


### PR DESCRIPTION
Introduces `UploadFile` value object to carry information about the original file to the provider.

This causes bc break as we are changing the signature of `RemoteMediaProvider::upload` method.