### PR TITLE
Make cache aware of the listing type

### DIFF
--- a/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
+++ b/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
@@ -231,13 +231,7 @@ class CloudinaryProvider extends RemoteMediaProvider
      */
     public function listResources($limit = 10, $offset = 0, $resource_type = 'image')
     {
-        $options = array(
-            'tags' => true,
-            'context' => true,
-            'resource_type' => $resource_type
-        );
-
-        return $this->gateway->listResources($options, $limit, $offset);
+        return $this->gateway->listResources($resource_type, $limit, $offset);
     }
 
     /**

--- a/RemoteMedia/Provider/Cloudinary/Gateway.php
+++ b/RemoteMedia/Provider/Cloudinary/Gateway.php
@@ -39,13 +39,13 @@ abstract class Gateway
     /**
      * List all available resources.
      *
-     * @param $options
+     * @param $type
      * @param $limit
      * @param $offset
      *
      * @return array
      */
-    public abstract function listResources($options, $limit, $offset);
+    public abstract function listResources($type, $limit, $offset);
 
     /**
      * Lists all available folders.

--- a/RemoteMedia/Provider/Cloudinary/Gateway/CachedGateway.php
+++ b/RemoteMedia/Provider/Cloudinary/Gateway/CachedGateway.php
@@ -100,19 +100,19 @@ class CachedGateway extends Gateway
     /**
      * List all available resources.
      *
-     * @param $options
+     * @param $type
      * @param $limit
      * @param $offset
      *
      * @return array
      */
-    public function listResources($options, $limit, $offset)
+    public function listResources($type, $limit, $offset)
     {
-        $cacheItem = $this->cache->getItem(array(self::PROJECT_KEY, self::PROVIDER_KEY, self::LIST));
+        $cacheItem = $this->cache->getItem(array(self::PROJECT_KEY, self::PROVIDER_KEY, self::LIST, $type));
         $list = $cacheItem->get();
 
         if ($cacheItem->isMiss()) {
-            $list = $this->gateway->listResources($options, $limit, $offset);
+            $list = $this->gateway->listResources($type, $limit, $offset);
             $this->cache->saveItem($cacheItem, $list, $this->ttl);
         }
 

--- a/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
+++ b/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
@@ -201,14 +201,19 @@ class CloudinaryApiGateway extends Gateway
      * Max limit for this endpoint is 500.
      * @see \Netgen\Bundle\RemoteMediaBundle\RemoteMedia\Provider\Cloudinary\Gateway\CachedGateway.php
      *
-     * @param $options
+     * @param $type
      * @param $limit
      * @param $offset
      *
      * @return array
      */
-    public function listResources($options, $limit, $offset)
+    public function listResources($type, $limit, $offset)
     {
+        $options = array(
+            'tags' => true,
+            'context' => true,
+            'resource_type' => $type
+        );
         $options['max_results'] = 500;
 
         $resources = $this->cloudinaryApi->resources($options)->getArrayCopy();

--- a/Tests/RemoteMedia/Provider/Cloudinary/CloudinaryProviderTest.php
+++ b/Tests/RemoteMedia/Provider/Cloudinary/CloudinaryProviderTest.php
@@ -78,15 +78,8 @@ class CloudinaryProviderTest extends TestCase
         $this->gateway
             ->expects($this->once())
             ->method('listResources')
-            ->with(
-                array(
-                    'tags' => true,
-                    'context' => true,
-                    'resource_type' => 'image'
-                ),
-                10,
-                0
-            );
+            ->with('image', 10, 0)
+        ;
 
         $this->cloudinaryProvider->listResources();
     }
@@ -98,15 +91,8 @@ class CloudinaryProviderTest extends TestCase
         $this->gateway
             ->expects($this->once())
             ->method('listResources')
-            ->with(
-                array(
-                    'tags' => true,
-                    'context' => true,
-                    'resource_type' => 'image'
-                ),
-                20,
-                0
-            );
+            ->with('image', 20, 0)
+        ;
 
         $this->cloudinaryProvider->listResources(20);
     }
@@ -118,15 +104,8 @@ class CloudinaryProviderTest extends TestCase
         $this->gateway
             ->expects($this->once())
             ->method('listResources')
-            ->with(
-                array(
-                    'tags' => true,
-                    'context' => true,
-                    'resource_type' => 'image'
-                ),
-                20,
-                5
-            );
+            ->with('image', 20, 5)
+        ;
 
         $this->cloudinaryProvider->listResources(20, 5);
     }

--- a/Tests/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGatewayTest.php
+++ b/Tests/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGatewayTest.php
@@ -138,7 +138,10 @@ class CloudinaryApiGatewayTest extends TestCase
     public function testListResource()
     {
         $apiOptions = array(
-            'max_results' => 500
+            'max_results' => 500,
+            'tags' => true,
+            'context' => true,
+            'resource_type' => 'image'
         );
 
         $this->cloudinaryApi->method('resources')->willReturn(new \ArrayObject(array('resources' => array())));
@@ -148,12 +151,17 @@ class CloudinaryApiGatewayTest extends TestCase
             ->method('resources')
             ->with($apiOptions);
 
-        $this->apiGateway->listResources([], 20, 0);
+        $this->apiGateway->listResources('image', 20, 0);
     }
 
     public function testListResourcesWithMoreResults()
     {
-        $options1 = array('max_results' => 500);
+        $options1 = array(
+            'max_results' => 500,
+            'tags' => true,
+            'context' => true,
+            'resource_type' => 'image'
+        );
         $options2 = $options1 + array('next_cursor' => 123);
 
         $this->cloudinaryApi
@@ -168,7 +176,7 @@ class CloudinaryApiGatewayTest extends TestCase
             ->method('resources')
             ->withConsecutive([$options1], [$options2]);
 
-        $this->apiGateway->listResources(array(), 0, 20);
+        $this->apiGateway->listResources('image', 0, 20);
     }
 
     public function testListFolders()


### PR DESCRIPTION
This should fix the issue where the listings get cached on the first view, and when changing to "video" the same list is displayed as it is being pulled from cache.