### PR TITLE
Make cache aware of the resource type when fething

### DIFF
--- a/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
+++ b/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
@@ -326,14 +326,7 @@ class CloudinaryProvider extends RemoteMediaProvider
             return new Value();
         }
 
-        $options = array(
-            'resource_type' => $resourceType,
-            'max_results' => 1,
-            'tags' => true,
-            'context' => true,
-        );
-
-        $response = $this->gateway->get($resourceId, $options);
+        $response = $this->gateway->get($resourceId, $resourceType);
 
         if (empty($response)) {
             return new Value();

--- a/RemoteMedia/Provider/Cloudinary/Gateway.php
+++ b/RemoteMedia/Provider/Cloudinary/Gateway.php
@@ -2,6 +2,9 @@
 
 namespace Netgen\Bundle\RemoteMediaBundle\RemoteMedia\Provider\Cloudinary;
 
+/**
+ * @internal
+ */
 abstract class Gateway
 {
     /**
@@ -74,11 +77,11 @@ abstract class Gateway
      * Fetches the remote resource by id.
      *
      * @param $id
-     * @param $options
+     * @param $type
      *
      * @return array
      */
-    public abstract function get($id, $options);
+    public abstract function get($id, $type);
 
     /**
      * Adds new tag to the remote resource.

--- a/RemoteMedia/Provider/Cloudinary/Gateway/CachedGateway.php
+++ b/RemoteMedia/Provider/Cloudinary/Gateway/CachedGateway.php
@@ -171,18 +171,18 @@ class CachedGateway extends Gateway
      * Fetches the remote resource by id.
      *
      * @param $id
-     * @param $options
+     * @param $type
      *
      * @return array
      */
-    public function get($id, $options)
+    public function get($id, $type)
     {
-        $cacheItem = $this->cache->getItem(array(self::PROJECT_KEY, self::PROVIDER_KEY, self::RESOURCE_ID, $id));
+        $cacheItem = $this->cache->getItem(array(self::PROJECT_KEY, self::PROVIDER_KEY, self::RESOURCE_ID, $id, $type));
 
         $value = $cacheItem->get();
 
         if ($cacheItem->isMiss()) {
-            $value = $this->gateway->get($id, $options);
+            $value = $this->gateway->get($id, $type);
             $this->cache->saveItem($cacheItem, $value, $this->ttl);
         }
 

--- a/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
+++ b/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
@@ -285,12 +285,19 @@ class CloudinaryApiGateway extends Gateway
      * Fetches the remote resource by id.
      *
      * @param $id
-     * @param $options
+     * @param $type
      *
      * @return array
      */
-    public function get($id, $options)
+    public function get($id, $type)
     {
+        $options = array(
+            'resource_type' => $type,
+            'max_results' => 1,
+            'tags' => true,
+            'context' => true,
+        );
+
         $response = $this->cloudinaryApi->resources_by_ids(
             array($id),
             $options

--- a/Tests/RemoteMedia/Provider/Cloudinary/CloudinaryProviderTest.php
+++ b/Tests/RemoteMedia/Provider/Cloudinary/CloudinaryProviderTest.php
@@ -245,13 +245,6 @@ class CloudinaryProviderTest extends TestCase
 
     public function testGetRemoteResource()
     {
-        $options = array(
-            'resource_type' => 'image',
-            'max_results' => 1,
-            'tags' => true,
-            'context' => true,
-        );
-
         $this->gateway->method('get')->willReturn(
             array(
                 'public_id' => 'testResourceId',
@@ -265,7 +258,7 @@ class CloudinaryProviderTest extends TestCase
         $this->gateway
             ->expects($this->once())
             ->method('get')
-            ->with('testResourceId', $options);
+            ->with('testResourceId', 'image');
 
         $value = $this->cloudinaryProvider->getRemoteResource('testResourceId', 'image');
 
@@ -294,13 +287,6 @@ class CloudinaryProviderTest extends TestCase
 
     public function testGetRemoteVideo()
     {
-        $options = array(
-            'resource_type' => 'video',
-            'max_results' => 1,
-            'tags' => true,
-            'context' => true,
-        );
-
         $this->gateway->method('get')->willReturn(
             array(
                 'public_id' => 'testResourceId',
@@ -314,7 +300,7 @@ class CloudinaryProviderTest extends TestCase
         $this->gateway
             ->expects($this->once())
             ->method('get')
-            ->with('testResourceId', $options);
+            ->with('testResourceId', 'video');
 
         $value = $this->cloudinaryProvider->getRemoteResource('testResourceId', 'video');
 
@@ -327,13 +313,6 @@ class CloudinaryProviderTest extends TestCase
 
     public function testGetRemoteDocument()
     {
-        $options = array(
-            'resource_type' => 'image',
-            'max_results' => 1,
-            'tags' => true,
-            'context' => true,
-        );
-
         $this->gateway->method('get')->willReturn(
             array(
                 'public_id' => 'testResourceId',
@@ -348,7 +327,7 @@ class CloudinaryProviderTest extends TestCase
         $this->gateway
             ->expects($this->once())
             ->method('get')
-            ->with('testResourceId', $options);
+            ->with('testResourceId', 'image');
 
         $value = $this->cloudinaryProvider->getRemoteResource('testResourceId', 'image');
 

--- a/Tests/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGatewayTest.php
+++ b/Tests/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGatewayTest.php
@@ -221,7 +221,13 @@ class CloudinaryApiGatewayTest extends TestCase
 
     public function testGetNotExistingResource()
     {
-        $options = array();
+        $options = array(
+            'resource_type' => 'image',
+            'max_results' => 1,
+            'tags' => true,
+            'context' => true,
+        );
+
 
         $this->cloudinaryApi
             ->method('resources_by_ids')
@@ -232,7 +238,7 @@ class CloudinaryApiGatewayTest extends TestCase
             ->method('resources_by_ids')
             ->with(array('test_id'), $options);
 
-        $result = $this->apiGateway->get('test_id', $options);
+        $result = $this->apiGateway->get('test_id', 'image');
 
         $this->assertEquals(
             array(),


### PR DESCRIPTION
This should fix the issue where the remote resource was first attempted to fetch as 'image', and then as 'video'. However, because of the wrong cache keys, the first response got cached, making it impossible to fetch videos remotely.

NB: we probably shouldn't cache empty responses, those should always go to the source. Should be taken care of in a separate PR.