### PR TITLE
[alpha] fix: user can not add tags in admin panel for remote image. 

### DIFF
--- a/ezpublish_legacy/ngremotemedia/design/standard/templates/content/datatype/edit/ngremotemedia.tpl
+++ b/ezpublish_legacy/ngremotemedia/design/standard/templates/content/datatype/edit/ngremotemedia.tpl
@@ -30,7 +30,7 @@
 
 {def $user=fetch( 'user', 'current_user' )}
 
-<div class="ngremotemedia-type" data-bootstrap-media={$remote_value|json} data-user-id="{$user.contentobject_id}">
+<div class="ngremotemedia-type" data-bootstrap-media="{$remote_value|json|wash()}" data-user-id="{$user.contentobject_id}">
     {include uri="design:parts/ngremotemedia/preview.tpl"}
     {include uri="design:parts/ngremotemedia/interactions.tpl"}
 </div>


### PR DESCRIPTION
Fix only for alpha (not relevant in 1.0+ stable releases). 

Before this PR, you will get an error in the network request that adds a tag:
https://site.dev/admin/ngremotemedia/tags/418737/7130197/14
`{"error_text": "Resource id must not be empty"}`


Fixes invalid json in data-bootstrap-media. Quotes ruins the parsing. After this you can add tags in the admin panel. 

This populates correct data to the Backbone.JS models ( https://github.com/netgen/NetgenRemoteMediaBundle/blob/1.x-alpha/ezpublish_legacy/ngremotemedia/design/standard/javascript/ngremotemedia/run.js#L8 ) .


