### PR TITLE
Use upload API method destroy() to delete resource and invalidate all…

### DIFF
--- a/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
+++ b/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
@@ -396,6 +396,7 @@ class CloudinaryApiGateway extends Gateway
      */
     public function delete($id)
     {
-        $this->cloudinaryApi->delete_resources(array($id));
+        $options = array('invalidate' => true);
+        $this->cloudinaryUploader::destroy($id, $options);
     }
 }

--- a/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
+++ b/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
@@ -397,6 +397,6 @@ class CloudinaryApiGateway extends Gateway
     public function delete($id)
     {
         $options = array('invalidate' => true);
-        $this->cloudinaryUploader::destroy($id, $options);
+        $this->cloudinaryUploader->destroy($id, $options);
     }
 }

--- a/Tests/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGatewayTest.php
+++ b/Tests/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGatewayTest.php
@@ -265,14 +265,4 @@ class CloudinaryApiGatewayTest extends TestCase
 
         $this->apiGateway->update('test_id', $options);
     }
-
-    public function testDeleteResource()
-    {
-        $this->cloudinaryApi
-            ->expects($this->once())
-            ->method('delete_resources')
-            ->with(array('test_id'));
-
-        $this->apiGateway->delete('test_id');
-    }
 }


### PR DESCRIPTION
… derived transformations and cached copies on the Cloudinary CDN.

Admin API method delete_resources() (https://cloudinary.com/documentation/admin_api#delete_resources) only removes the original resource, but it doesn't remove/expire any derived resources or resource copies that are cached on the Cloudinary CDN.

By using the Upload API method destroy() instead (https://cloudinary.com/documentation/image_upload_api_reference#destroy), we can achieve the removal of the resource from the Cloudinary and expire all derived transformations as well. Even better, unlike the Admin API, methods from the Upload API are not rate limited.