### PR TITLE
Keep extension of uploaded file

### DIFF
--- a/RemoteMedia/RemoteMediaProvider.php
+++ b/RemoteMedia/RemoteMediaProvider.php
@@ -51,6 +51,9 @@ abstract class RemoteMediaProvider
     abstract public function supportsFolders();
 
     /**
+     * @deprecated this method will have a different signature in 2.0
+     * @see \Netgen\Bundle\RemoteMediaBundle\RemoteMedia\RemoteMediaProvider::uploadWithExtension
+     *
      * Uploads the local resource to remote storage and builds the Value from the response.
      *
      * @param string $fileUri
@@ -60,6 +63,16 @@ abstract class RemoteMediaProvider
      * @return Value
      */
     abstract public function upload($fileUri, $fileName, $options = array());
+
+    /**
+     * Uploads the local resource to remote storage and builds the Value from the response.
+     *
+     * @param \Netgen\Bundle\RemoteMediaBundle\RemoteMedia\UploadFile $uploadFile
+     * @param array $options
+     *
+     * @return mixed
+     */
+    abstract public function uploadWithExtension(UploadFile $uploadFile, $options = array());
 
     /**
      * Gets the remote media Variation.

--- a/RemoteMedia/UploadFile.php
+++ b/RemoteMedia/UploadFile.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Netgen\Bundle\RemoteMediaBundle\RemoteMedia;
+
+use \eZHTTPFile;
+use eZ\Publish\Core\FieldType\Image\Value;
+
+class UploadFile
+{
+    private $uri;
+
+    private $originalFilename;
+
+    private $originalExtension;
+
+    private function __construct() {}
+
+    /**
+     * Constructs UploadFile from given uri.
+     *
+     * @param $uri
+     *
+     * @return UploadFile
+     */
+    public static function fromUri($uri)
+    {
+        $uploadFile = new UploadFile;
+
+        $uploadFile->uri = $uri;
+        $uploadFile->originalFilename = pathinfo($uri, PATHINFO_FILENAME);
+        $uploadFile->originalExtension = pathinfo($uri, PATHINFO_EXTENSION);
+
+        return $uploadFile;
+    }
+
+    /**
+     * Constructs UploadFile from given eZHTTPFile (usually uploaded through the legacy admin).
+     *
+     * @param eZHTTPFile $file
+     *
+     * @return UploadFile
+     */
+    public static function fromZHTTPFile(eZHTTPFile $file)
+    {
+        $uploadFile = new UploadFile;
+
+        $uploadFile->uri = $file->Filename;
+        $uploadFile->originalFilename = pathinfo($file->OriginalFilename, PATHINFO_FILENAME);
+        $uploadFile->originalExtension = pathinfo($file->OriginalFilename, PATHINFO_EXTENSION);
+
+        return $uploadFile;
+    }
+
+    /**
+     * Constructs UploadFile from given eZImage field Value.
+     *
+     * @param Value $value
+     * @param $webRoot
+     *
+     * @return UploadFile
+     */
+    public static function fromEzImageValue(Value $value, $webRoot)
+    {
+        $uploadFile = new UploadFile;
+
+        $uploadFile->uri = $webRoot.$value->uri;
+        $uploadFile->originalFilename = pathinfo($value->fileName, PATHINFO_FILENAME);
+        $uploadFile->originalExtension = pathinfo($value->fileName, PATHINFO_EXTENSION);
+
+        return $uploadFile;
+    }
+
+    /**
+     * @return string
+     */
+    public function uri()
+    {
+        return $this->uri;
+    }
+
+    /**
+     * @return string
+     */
+    public function originalFilename()
+    {
+        return $this->originalFilename;
+    }
+
+    /**
+     * @return string
+     */
+    public function originalExtension()
+    {
+        return $this->originalExtension;
+    }
+}

--- a/ezpublish_legacy/ngremotemedia/modules/ngremotemedia/simple_upload.php
+++ b/ezpublish_legacy/ngremotemedia/modules/ngremotemedia/simple_upload.php
@@ -1,5 +1,7 @@
 <?php
 
+use Netgen\Bundle\RemoteMediaBundle\RemoteMedia\UploadFile;
+
 $http = eZHTTPTool::instance();
 
 $file = eZHTTPFile::fetch( 'file' );
@@ -23,10 +25,8 @@ if (empty($file) || empty($fieldId) || empty($contentId) || empty($contentVersio
 $container = ezpKernel::instance()->getServiceContainer();
 $provider = $container->get( 'netgen_remote_media.provider' );
 
-$value = $provider->upload(
-    $file->Filename,
-    pathinfo($file->OriginalFilename, PATHINFO_FILENAME)
-);
+$uploadFile = UploadFile::fromZHTTPFile($file);
+$value = $provider->uploadWithExtension($uploadFile);
 
 $responseData = array(
     'media' => !empty($value->resourceId) ? $value : false,

--- a/ezpublish_legacy/ngremotemedia/modules/ngremotemedia/upload.php
+++ b/ezpublish_legacy/ngremotemedia/modules/ngremotemedia/upload.php
@@ -1,5 +1,7 @@
 <?php
 
+use Netgen\Bundle\RemoteMediaBundle\RemoteMedia\UploadFile;
+
 $http = eZHTTPTool::instance();
 
 $contentId = $Params['contentobject_id'];
@@ -29,7 +31,8 @@ if ($folder !== 'all') {
     $options['folder'] = $folder;
 }
 
-$value = $provider->upload($file->Filename, pathinfo($file->OriginalFilename, PATHINFO_FILENAME), $options);
+$uploadFile = UploadFile::fromZHTTPFile($file);
+$value = $provider->uploadWithExtension($uploadFile, $options);
 
 $attribute = eZContentObjectAttribute::fetch($fieldId, $contentVersionId);
 $attribute->setAttribute('data_text', json_encode($value));


### PR DESCRIPTION
Introduces UploadFile value object to carry information about the original file to the provider.

`RemoteMediaProvider::upload` method has been marked as deprecated in favour of the new implementation which will replace it in 2.0 release