### PR TITLE
NGSTACK-672 Remove urlencode for IDs when fetching remote resource

### DIFF
--- a/bundle/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
+++ b/bundle/RemoteMedia/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
@@ -264,12 +264,6 @@ class CloudinaryApiGateway extends Gateway
     public function get($id, $type)
     {
         try {
-            $id = array_map(function (string $part) {
-                return urlencode($part);
-            }, explode('/', $id));
-
-            $id = implode('/', $id);
-
             return (array) $this->cloudinaryApi->resource($id, ['resource_type' => $type]);
         } catch (Cloudinary\Error $e) {
             return [];


### PR DESCRIPTION
At some point, `urlencode` was introduced because there were some issues with unicode characters (such as eg. Croatian or Norwegian letters) but now it seems that `urlencode` is actually causing those issues because requesting a resource with ID that contains unicode characters will result with 404.

I've removed this now and in my tests it works flawlesly, both with `resource()` and `explicit()` methods from Cloudinary API. I've tested with file named `Birthday čšćđžæø !"#%&$#.png` and it has been uploaded as `Birthday_čšćđžæø_h9dzhmrmgu` and works normally.