### PR TITLE
Feature/move action

### DIFF
--- a/lib/API/ProviderInterface.php
+++ b/lib/API/ProviderInterface.php
@@ -75,7 +75,11 @@ interface ProviderInterface
 
     public function store(RemoteResource $resource): RemoteResource;
 
+    public function move(RemoteResource $resource, ?Folder $destinationFolder): RemoteResource;
+
     public function remove(RemoteResource $resource): void;
+
+    public function moveOnRemote(RemoteResource $resource, ?Folder $destinationFolder): RemoteResource;
 
     public function deleteFromRemote(RemoteResource $resource): void;
 

--- a/lib/Core/AbstractProvider.php
+++ b/lib/Core/AbstractProvider.php
@@ -154,6 +154,26 @@ abstract class AbstractProvider implements ProviderInterface
         return $existingResource;
     }
 
+    public function move(RemoteResource $resource, ?Folder $destinationFolder): RemoteResource
+    {
+        $newResource = $this->moveOnRemote($resource, $destinationFolder);
+
+        try {
+            $existingResource = $resource->getId() !== null
+                ? $this->load($resource->getId())
+                : $this->loadByRemoteId($resource->getRemoteId());
+
+            $existingResource->refresh($newResource);
+
+            $this->store($existingResource);
+
+            return $existingResource;
+        } catch (RemoteResourceNotFoundException $e) {
+        }
+
+        return $newResource;
+    }
+
     public function remove(RemoteResource $resource): void
     {
         $this->entityManager->remove($resource);

--- a/lib/Core/Provider/Cloudinary/CloudinaryProvider.php
+++ b/lib/Core/Provider/Cloudinary/CloudinaryProvider.php
@@ -145,7 +145,7 @@ final class CloudinaryProvider extends AbstractProvider
         }
 
         $options = [
-            'asset_folder' => $destinationFolder?->getPath(),
+            'asset_folder' => $destinationFolder instanceof Folder ? $destinationFolder->getPath() : '/',
         ];
 
         $this->gateway->update(

--- a/lib/Core/Provider/Cloudinary/CloudinaryProvider.php
+++ b/lib/Core/Provider/Cloudinary/CloudinaryProvider.php
@@ -131,6 +131,33 @@ final class CloudinaryProvider extends AbstractProvider
         throw new RemoteResourceNotFoundException($remoteId);
     }
 
+    public function moveOnRemote(RemoteResource $resource, ?Folder $destinationFolder): RemoteResource
+    {
+        if ($this->folderMode === self::FOLDER_MODE_FIXED) {
+            $cloudinaryRemoteId = CloudinaryRemoteId::fromRemoteId($resource->getRemoteId(), $this->folderMode);
+            $newCloudinaryRemoteId = (clone $cloudinaryRemoteId)->move($destinationFolder);
+
+            $this->gateway->rename($cloudinaryRemoteId, $newCloudinaryRemoteId);
+
+            return $resource->refresh(
+                $this->loadFromRemote($newCloudinaryRemoteId->getRemoteId()),
+            );
+        }
+
+        $options = [
+            'asset_folder' => $destinationFolder?->getPath(),
+        ];
+
+        $this->gateway->update(
+            CloudinaryRemoteId::fromRemoteId($resource->getRemoteId(), $this->folderMode),
+            $options,
+        );
+
+        return $resource->refresh(
+            $this->loadFromRemote($resource->getRemoteId()),
+        );
+    }
+
     public function deleteFromRemote(RemoteResource $resource): void
     {
         $this->gateway->delete(

--- a/lib/Core/Provider/Cloudinary/CloudinaryRemoteId.php
+++ b/lib/Core/Provider/Cloudinary/CloudinaryRemoteId.php
@@ -12,7 +12,9 @@ use function array_pop;
 use function count;
 use function explode;
 use function implode;
+use function ltrim;
 use function sprintf;
+use function str_replace;
 
 final class CloudinaryRemoteId
 {
@@ -81,10 +83,7 @@ final class CloudinaryRemoteId
     public function getFolder(): ?Folder
     {
         if ($this->folderMode !== CloudinaryProvider::FOLDER_MODE_FIXED) {
-            throw new NotSupportedException(
-                'Cloudinary',
-                sprintf('fetching folder from path in "%s" folder mode', $this->folderMode),
-            );
+            throw new NotSupportedException('Cloudinary', sprintf('fetching folder from path in "%s" folder mode', $this->folderMode));
         }
 
         $resourceIdParts = explode('/', $this->resourceId);
@@ -95,5 +94,29 @@ final class CloudinaryRemoteId
         }
 
         return Folder::fromPath(implode('/', $resourceIdParts));
+    }
+
+    public function move(?Folder $folder): self
+    {
+        if ($this->folderMode !== CloudinaryProvider::FOLDER_MODE_FIXED) {
+            throw new NotSupportedException('Cloudinary', sprintf('moving to folder via public ID in %s folder mode', $this->folderMode));
+        }
+
+        $this->resourceId = $this->resolveNewResourceId($folder);
+
+        return $this;
+    }
+
+    private function resolveNewResourceId(?Folder $folder): string
+    {
+        $resourceId = $this->getFolder() instanceof Folder
+            ? ltrim(str_replace($this->getFolder()->getPath(), '', $this->resourceId), '/')
+            : $this->resourceId;
+
+        if (!$folder instanceof Folder) {
+            return $resourceId;
+        }
+
+        return sprintf('%s/%s', $folder->getPath(), $resourceId);
     }
 }

--- a/lib/Core/Provider/Cloudinary/Gateway/Cache/Psr6CachedGateway.php
+++ b/lib/Core/Provider/Cloudinary/Gateway/Cache/Psr6CachedGateway.php
@@ -216,6 +216,14 @@ final class Psr6CachedGateway implements CacheableGatewayInterface
         $this->invalidateTagsCache();
     }
 
+    public function rename(CloudinaryRemoteId $fromRemoteId, CloudinaryRemoteId $toRemoteId): void
+    {
+        $this->gateway->rename($fromRemoteId, $toRemoteId);
+
+        $this->invalidateResourceCache($fromRemoteId);
+        $this->invalidateResourceListCache();
+    }
+
     public function removeAllTagsFromResource(CloudinaryRemoteId $remoteId): void
     {
         $this->gateway->removeAllTagsFromResource($remoteId);

--- a/lib/Core/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
+++ b/lib/Core/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
@@ -193,6 +193,21 @@ final class CloudinaryApiGateway implements GatewayInterface
         }
     }
 
+    public function rename(CloudinaryRemoteId $fromRemoteId, CloudinaryRemoteId $toRemoteId): void
+    {
+        $options = [
+            'type' => $toRemoteId->getType(),
+            'resource_type' => $toRemoteId->getResourceType(),
+            'invalidate' => true,
+        ];
+
+        try {
+            $this->uploadApi->rename($fromRemoteId->getRemoteId(), $toRemoteId->getRemoteId(), $options);
+        } catch (CloudinaryNotFound $e) {
+            throw new RemoteResourceNotFoundException($fromRemoteId->getRemoteId());
+        }
+    }
+
     public function removeAllTagsFromResource(CloudinaryRemoteId $remoteId): void
     {
         $options = [

--- a/lib/Core/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
+++ b/lib/Core/Provider/Cloudinary/Gateway/CloudinaryApiGateway.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Netgen\RemoteMedia\Core\Provider\Cloudinary\Gateway;
 
 use Cloudinary\Api\Admin\AdminApi;
+use Cloudinary\Api\Exception\BadRequest as CloudinaryBadRequest;
 use Cloudinary\Api\Exception\NotFound as CloudinaryNotFound;
 use Cloudinary\Api\Search\SearchApi;
 use Cloudinary\Api\Upload\UploadApi;
@@ -202,9 +203,15 @@ final class CloudinaryApiGateway implements GatewayInterface
         ];
 
         try {
-            $this->uploadApi->rename($fromRemoteId->getRemoteId(), $toRemoteId->getRemoteId(), $options);
+            $this->uploadApi->rename($fromRemoteId->getResourceId(), $toRemoteId->getResourceId(), $options);
         } catch (CloudinaryNotFound $e) {
             throw new RemoteResourceNotFoundException($fromRemoteId->getRemoteId());
+        } catch (CloudinaryBadRequest $e) {
+            try {
+                throw new RemoteResourceExistsException($this->get($toRemoteId));
+            } catch (CloudinaryNotFound $e2) {
+                throw $e;
+            }
         }
     }
 

--- a/lib/Core/Provider/Cloudinary/Gateway/Log/MonologLoggedGateway.php
+++ b/lib/Core/Provider/Cloudinary/Gateway/Log/MonologLoggedGateway.php
@@ -93,6 +93,13 @@ final class MonologLoggedGateway implements GatewayInterface
         $this->gateway->update($remoteId, $options);
     }
 
+    public function rename(CloudinaryRemoteId $fromRemoteId, CloudinaryRemoteId $toRemoteId): void
+    {
+        $this->logger->info("[API][FREE] rename(\"{$fromRemoteId->getRemoteId()}\", \"{$toRemoteId->getRemoteId()}\") -> Cloudinary\\Uploader::explicit(\"{$fromRemoteId->getRemoteId()}\")");
+
+        $this->gateway->rename($fromRemoteId, $toRemoteId);
+    }
+
     public function removeAllTagsFromResource(CloudinaryRemoteId $remoteId): void
     {
         $this->logger->info("[API][FREE] removeAllTagsFromResource(\"{$remoteId->getRemoteId()}\") -> Cloudinary\\Api::remove_all_tags(\"{$remoteId->getRemoteId()}\")");

--- a/lib/Core/Provider/Cloudinary/GatewayInterface.php
+++ b/lib/Core/Provider/Cloudinary/GatewayInterface.php
@@ -58,6 +58,11 @@ interface GatewayInterface
     /**
      * @throws RemoteResourceNotFoundException
      */
+    public function rename(CloudinaryRemoteId $fromRemoteId, CloudinaryRemoteId $toRemoteId): void;
+
+    /**
+     * @throws RemoteResourceNotFoundException
+     */
     public function removeAllTagsFromResource(CloudinaryRemoteId $remoteId): void;
 
     public function delete(CloudinaryRemoteId $remoteId): void;

--- a/lib/Core/Provider/Cloudinary/GatewayInterface.php
+++ b/lib/Core/Provider/Cloudinary/GatewayInterface.php
@@ -57,6 +57,7 @@ interface GatewayInterface
 
     /**
      * @throws RemoteResourceNotFoundException
+     * @throws RemoteResourceExistsException
      */
     public function rename(CloudinaryRemoteId $fromRemoteId, CloudinaryRemoteId $toRemoteId): void;
 

--- a/tests/lib/Core/AbstractProviderTest.php
+++ b/tests/lib/Core/AbstractProviderTest.php
@@ -547,6 +547,103 @@ final class AbstractProviderTest extends AbstractTestCase
         );
     }
 
+    public function testMoveWithoutStored(): void
+    {
+        $remoteResource = new RemoteResource(
+            remoteId: 'media/images/test_image.jpg',
+            type: 'image',
+            url: 'https://cloudinary.com/upload/image/media/images/test_image.jpg',
+            md5: 'e522f43cf89aa0afd03387c37e2b6e29',
+            name: 'test_image.jpg',
+            folder: Folder::fromPath('media/images'),
+            size: 250,
+        );
+
+        $newRemoteResource = new RemoteResource(
+            remoteId: 'new/media/images/test_image.jpg',
+            type: 'image',
+            url: 'https://cloudinary.com/upload/image/new/media/images/test_image.jpg',
+            md5: 'e522f43cf89aa0afd03387c37e2b6e29',
+            name: 'test_image.jpg',
+            folder: Folder::fromPath('new/media/images'),
+            size: 250,
+        );
+
+        $this->provider
+            ->expects(self::once())
+            ->method('moveOnRemote')
+            ->with($remoteResource, Folder::fromPath('new/media/images'))
+            ->willReturn($newRemoteResource);
+
+        $this->resourceRepository
+            ->expects(self::once())
+            ->method('findOneBy')
+            ->with(['remoteId' => $remoteResource->getRemoteId()])
+            ->willReturn(null);
+
+        $returnedRemoteResource = $this->provider->move($remoteResource, Folder::fromPath('new/media/images'));
+
+        self::assertRemoteResourceSame($newRemoteResource, $returnedRemoteResource);
+    }
+
+    public function testMoveWithStored(): void
+    {
+        $remoteResource = new RemoteResource(
+            remoteId: 'media/images/test_image.jpg',
+            type: 'image',
+            url: 'https://cloudinary.com/upload/image/media/images/test_image.jpg',
+            md5: 'e522f43cf89aa0afd03387c37e2b6e29',
+            id: 5,
+            name: 'test_image.jpg',
+            folder: Folder::fromPath('media/images'),
+            size: 250,
+        );
+
+        $newRemoteResource = new RemoteResource(
+            remoteId: 'new/media/images/test_image.jpg',
+            type: 'image',
+            url: 'https://cloudinary.com/upload/image/new/media/images/test_image.jpg',
+            md5: 'e522f43cf89aa0afd03387c37e2b6e29',
+            id: 5,
+            name: 'test_image.jpg',
+            folder: Folder::fromPath('new/media/images'),
+            size: 250,
+        );
+
+        $this->provider
+            ->expects(self::once())
+            ->method('moveOnRemote')
+            ->with($remoteResource, Folder::fromPath('new/media/images'))
+            ->willReturn($newRemoteResource);
+
+        $this->resourceRepository
+            ->expects(self::once())
+            ->method('find')
+            ->with(5)
+            ->willReturn($remoteResource);
+
+        $dateTime = new DateTimeImmutable('now');
+        $newRemoteResource->setUpdatedAt($dateTime);
+
+        $this->dateTimeFactory
+            ->expects(self::once())
+            ->method('createCurrent')
+            ->willReturn($dateTime);
+
+        $this->entityManager
+            ->expects(self::once())
+            ->method('persist')
+            ->with($newRemoteResource);
+
+        $this->entityManager
+            ->expects(self::once())
+            ->method('flush');
+
+        $returnedRemoteResource = $this->provider->move($remoteResource, Folder::fromPath('new/media/images'));
+
+        self::assertRemoteResourceSame($newRemoteResource, $returnedRemoteResource);
+    }
+
     public function testRemove(): void
     {
         $remoteResource = new RemoteResource(

--- a/tests/lib/Core/Provider/Cloudinary/CloudinaryProviderTest.php
+++ b/tests/lib/Core/Provider/Cloudinary/CloudinaryProviderTest.php
@@ -41,6 +41,8 @@ final class CloudinaryProviderTest extends AbstractTestCase
 {
     protected CloudinaryProvider $cloudinaryProvider;
 
+    protected CloudinaryProvider $cloudinaryProviderDynamic;
+
     protected GatewayInterface|MockObject $gateway;
 
     protected LoggerInterface|MockObject $logger;
@@ -56,7 +58,7 @@ final class CloudinaryProviderTest extends AbstractTestCase
         $entityManager = $this->createMock(EntityManagerInterface::class);
 
         $entityManager
-            ->expects(self::exactly(2))
+            ->expects(self::exactly(4))
             ->method('getRepository')
             ->willReturnMap(
                 [
@@ -83,6 +85,28 @@ final class CloudinaryProviderTest extends AbstractTestCase
             [],
             [],
             CloudinaryProvider::FOLDER_MODE_FIXED,
+            $this->logger,
+            false,
+        );
+
+        $this->cloudinaryProviderDynamic = new CloudinaryProvider(
+            new Registry(),
+            new VariationResolver(
+                new Registry(),
+                new NullLogger(),
+            ),
+            $entityManager,
+            $this->gateway,
+            new DateTimeFactory(),
+            new UploadOptionsResolver(
+                new VisibilityTypeConverter(),
+                CloudinaryProvider::FOLDER_MODE_DYNAMIC,
+                ['image', 'video'],
+                $this->mimeTypes,
+            ),
+            [],
+            [],
+            CloudinaryProvider::FOLDER_MODE_DYNAMIC,
             $this->logger,
             false,
         );
@@ -234,6 +258,100 @@ final class CloudinaryProviderTest extends AbstractTestCase
         self::expectExceptionMessage('Remote resource with ID "image2.jpg" not found.');
 
         $this->cloudinaryProvider->loadFromRemote('image2.jpg');
+    }
+
+    public function testMoveOnRemoteFixed(): void
+    {
+        $resource = new RemoteResource(
+            remoteId: 'upload|image|media/images/image.jpg',
+            type: 'image',
+            url: 'https://cloudinary.com/test/upload/images/image.jpg',
+            md5: 'e522f43cf89aa0afd03387c37e2b6e29',
+            id: 3,
+            name: 'image.jpg',
+            folder: Folder::fromPath('media/images'),
+            size: 95,
+        );
+
+        $fetchedResource = new RemoteResource(
+            remoteId: 'upload|image|new/media/images/image.jpg',
+            type: 'image',
+            url: 'https://cloudinary.com/test/upload/images/image.jpg',
+            md5: 'e522f43cf89aa0afd03387c37e2b6e29',
+            name: 'image.jpg',
+            folder: Folder::fromPath('new/media/images'),
+            size: 95,
+        );
+
+        $targetResource = new RemoteResource(
+            remoteId: 'upload|image|new/media/images/image.jpg',
+            type: 'image',
+            url: 'https://cloudinary.com/test/upload/images/image.jpg',
+            md5: 'e522f43cf89aa0afd03387c37e2b6e29',
+            id: 3,
+            name: 'image.jpg',
+            folder: Folder::fromPath('new/media/images'),
+            size: 95,
+        );
+
+        $this->gateway
+            ->expects(self::once())
+            ->method('rename')
+            ->with(
+                CloudinaryRemoteId::fromRemoteId('upload|image|media/images/image.jpg'),
+                CloudinaryRemoteId::fromRemoteId('upload|image|new/media/images/image.jpg'),
+            );
+
+        $this->gateway
+            ->expects(self::once())
+            ->method('get')
+            ->with(CloudinaryRemoteId::fromRemoteId('upload|image|new/media/images/image.jpg'))
+            ->willReturn($fetchedResource);
+
+        $returnedResource = $this->cloudinaryProvider->moveOnRemote($resource, Folder::fromPath('new/media/images'));
+
+        self::assertRemoteResourceSame($targetResource, $returnedResource);
+    }
+
+    public function testMoveOnRemoteDynamic(): void
+    {
+        $resource = new RemoteResource(
+            remoteId: 'upload|image|image.jpg',
+            type: 'image',
+            url: 'https://cloudinary.com/test/upload/image.jpg',
+            md5: 'e522f43cf89aa0afd03387c37e2b6e29',
+            name: 'image.jpg',
+            folder: Folder::fromPath('media/images'),
+            size: 95,
+        );
+
+        $targetResource = new RemoteResource(
+            remoteId: 'upload|image|image.jpg',
+            type: 'image',
+            url: 'https://cloudinary.com/test/upload/image.jpg',
+            md5: 'e522f43cf89aa0afd03387c37e2b6e29',
+            name: 'image.jpg',
+            folder: Folder::fromPath('new/media/images'),
+            size: 95,
+        );
+
+        $this->gateway
+            ->expects(self::once())
+            ->method('update')
+            ->with(
+                CloudinaryRemoteId::fromRemoteId('upload|image|image.jpg', CloudinaryProvider::FOLDER_MODE_DYNAMIC),
+                ['asset_folder' => 'new/media/images'],
+            );
+
+        $this->gateway
+            ->expects(self::once())
+            ->method('get')
+            ->with(CloudinaryRemoteId::fromRemoteId('upload|image|image.jpg', CloudinaryProvider::FOLDER_MODE_DYNAMIC))
+            ->willReturn($targetResource);
+
+        $returnedResource = $this->cloudinaryProviderDynamic->moveOnRemote($resource, Folder::fromPath('new/media/images'));
+
+        self::assertRemoteResourceSame($targetResource, $returnedResource);
     }
 
     public function testDeleteFromRemote(): void

--- a/tests/lib/Core/Provider/Cloudinary/CloudinaryRemoteIdTest.php
+++ b/tests/lib/Core/Provider/Cloudinary/CloudinaryRemoteIdTest.php
@@ -165,4 +165,50 @@ final class CloudinaryRemoteIdTest extends AbstractTestCase
 
         CloudinaryRemoteId::fromRemoteId('image|some_image.jpg');
     }
+
+    public function testMove(): void
+    {
+        $cloudinaryRemoteId = CloudinaryRemoteId::fromRemoteId('upload|image|media/images/some_image.jpg');
+        $cloudinaryRemoteId->move(Folder::fromPath('new/media/images'));
+
+        self::assertSame('upload|image|new/media/images/some_image.jpg', $cloudinaryRemoteId->getRemoteId());
+        self::assertSame('new/media/images/some_image.jpg', $cloudinaryRemoteId->getResourceId());
+        self::assertSame('upload', $cloudinaryRemoteId->getType());
+        self::assertSame('image', $cloudinaryRemoteId->getResourceType());
+        self::assertFolderSame(Folder::fromPath('new/media/images'), $cloudinaryRemoteId->getFolder());
+    }
+
+    public function testMoveToRoot(): void
+    {
+        $cloudinaryRemoteId = CloudinaryRemoteId::fromRemoteId('upload|image|media/images/some_image.jpg');
+        $cloudinaryRemoteId->move(null);
+
+        self::assertSame('upload|image|some_image.jpg', $cloudinaryRemoteId->getRemoteId());
+        self::assertSame('some_image.jpg', $cloudinaryRemoteId->getResourceId());
+        self::assertSame('upload', $cloudinaryRemoteId->getType());
+        self::assertSame('image', $cloudinaryRemoteId->getResourceType());
+        self::assertNull($cloudinaryRemoteId->getFolder());
+    }
+
+    public function testMoveFromRoot(): void
+    {
+        $cloudinaryRemoteId = CloudinaryRemoteId::fromRemoteId('upload|image|some_image.jpg');
+        $cloudinaryRemoteId->move(Folder::fromPath('new/media/images'));
+
+        self::assertSame('upload|image|new/media/images/some_image.jpg', $cloudinaryRemoteId->getRemoteId());
+        self::assertSame('new/media/images/some_image.jpg', $cloudinaryRemoteId->getResourceId());
+        self::assertSame('upload', $cloudinaryRemoteId->getType());
+        self::assertSame('image', $cloudinaryRemoteId->getResourceType());
+        self::assertFolderSame(Folder::fromPath('new/media/images'), $cloudinaryRemoteId->getFolder());
+    }
+
+    public function testMoveDynamicFolder(): void
+    {
+        $cloudinaryRemoteId = CloudinaryRemoteId::fromRemoteId('upload|image|some_image.jpg', CloudinaryProvider::FOLDER_MODE_DYNAMIC);
+
+        self::expectException(NotSupportedException::class);
+        self::expectExceptionMessage('Provider "Cloudinary" does not support "moving to folder via public ID in dynamic folder mode".');
+
+        $cloudinaryRemoteId->move(Folder::fromPath('test'));
+    }
 }

--- a/tests/lib/Core/Provider/Cloudinary/Gateway/Cache/Psr6CachedGatewayTest.php
+++ b/tests/lib/Core/Provider/Cloudinary/Gateway/Cache/Psr6CachedGatewayTest.php
@@ -534,6 +534,19 @@ final class Psr6CachedGatewayTest extends AbstractTestCase
         $this->nonTaggableCachedGateway->update($remoteId, $options);
     }
 
+    public function testRename(): void
+    {
+        $fromRemoteId = CloudinaryRemoteId::fromRemoteId('upload|image|media/images/test_image.jpg');
+        $toRemoteId = CloudinaryRemoteId::fromRemoteId('upload|image|new/media/images/test_image.jpg');
+
+        $this->apiGatewayMock
+            ->expects(self::once())
+            ->method('rename')
+            ->with($fromRemoteId, $toRemoteId);
+
+        $this->nonTaggableCachedGateway->rename($fromRemoteId, $toRemoteId);
+    }
+
     public function testRemoveAllTagsFromResource(): void
     {
         $remoteId = CloudinaryRemoteId::fromRemoteId('upload|image|test_image.jpg');

--- a/tests/lib/Core/Provider/Cloudinary/Gateway/Log/MonologLoggedGatewayTest.php
+++ b/tests/lib/Core/Provider/Cloudinary/Gateway/Log/MonologLoggedGatewayTest.php
@@ -276,6 +276,24 @@ final class MonologLoggedGatewayTest extends AbstractTestCase
         $this->gateway->update($remoteId, $options);
     }
 
+    public function testRename(): void
+    {
+        $fromRemoteId = CloudinaryRemoteId::fromRemoteId('upload|image|media/images/test_image.jpg');
+        $toRemoteId = CloudinaryRemoteId::fromRemoteId('upload|image|new/media/images/test_image.jpg');
+
+        $this->apiGatewayMock
+            ->expects(self::once())
+            ->method('rename')
+            ->with($fromRemoteId, $toRemoteId);
+
+        $this->loggerMock
+            ->expects(self::once())
+            ->method('info')
+            ->with("[API][FREE] rename(\"{$fromRemoteId->getRemoteId()}\", \"{$toRemoteId->getRemoteId()}\") -> Cloudinary\\Uploader::explicit(\"{$fromRemoteId->getRemoteId()}\")");
+
+        $this->gateway->rename($fromRemoteId, $toRemoteId);
+    }
+
     public function testRemoveAllTagsFromResource(): void
     {
         $remoteId = CloudinaryRemoteId::fromRemoteId('upload|image|test_image.jpg');


### PR DESCRIPTION
This PR introduces new feature to move resources from one folder to another (including moving to root as well). It's possible to move it only on remote, or move it with also updating locally stored resources. Also, it automatically triggers all cache invalidation.

Moving is supported for both DYNAMIC and FIXED folder mode. For DYNAMIC mode it's simple, as folder is just a metadata, and resourceId as well as URL remain the same and nothing breaks. For FIXED mode, it's using "rename" option in the background, which changes resourceId as well as URL so all old URLs will no longer work.