### PR TITLE
JGLWEB-130 add resource type to cloudinary to propery generate video url

### DIFF
--- a/bundle/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
+++ b/bundle/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
@@ -118,6 +118,7 @@ class CloudinaryProvider extends RemoteMediaProvider
 
         $finalOptions['transformation'] = $options;
         $finalOptions['resource_type'] = $value->resourceType;
+        $finalOptions['type'] = $value->type;
         $finalOptions['secure'] = $secure;
 
         $url = $this->gateway->getVariationUrl($value->resourceId, $finalOptions);

--- a/bundle/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
+++ b/bundle/RemoteMedia/Provider/Cloudinary/CloudinaryProvider.php
@@ -117,6 +117,7 @@ class CloudinaryProvider extends RemoteMediaProvider
         }
 
         $finalOptions['transformation'] = $options;
+        $finalOptions['resource_type'] = $value->resourceType;
         $finalOptions['secure'] = $secure;
 
         $url = $this->gateway->getVariationUrl($value->resourceId, $finalOptions);


### PR DESCRIPTION
The updated function `buildVariationUrl` gets called when using `netgen_remote_variation` in twig, but it's missing `resource_type` in the options used with cloudinary's API. When the fn is then used with a video, the resulting URL ends up with `/image/` instead of `/video/` because cloudinary's code falls back to `image` for `resource_type`, and that URL does not work.