### PR TITLE
Handle Encrypted PDF files

### DIFF
--- a/bundle/Controller/Resource/Upload.php
+++ b/bundle/Controller/Resource/Upload.php
@@ -128,7 +128,7 @@ final class Upload extends AbstractController
 
     private function isEncryptedPdf(UploadedFile $file): bool
     {
-        if (strtolower((string) $file->getClientOriginalExtension()) !== 'pdf') {
+        if (strtolower($file->getClientOriginalExtension()) !== 'pdf') {
             return false;
         }
 
@@ -144,8 +144,6 @@ final class Upload extends AbstractController
 
         $head = (string) fread($fp, 4096);
 
-        // Encryption marker may be located anywhere; read also from the end.
-        // Suppress fseek errors (e.g. very small files).
         @fseek($fp, -16384, SEEK_END);
         $tail = (string) fread($fp, 16384);
 

--- a/bundle/Controller/Resource/Upload.php
+++ b/bundle/Controller/Resource/Upload.php
@@ -18,9 +18,19 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+use function fclose;
+use function fopen;
+use function fread;
+use function fseek;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_file;
+use function is_readable;
+use function strpos;
+use function strtolower;
+
+use const SEEK_END;
 
 final class Upload extends AbstractController
 {
@@ -88,9 +98,11 @@ final class Upload extends AbstractController
 
         $md5 = $this->fileHashFactory->createHash($file->getRealPath());
         $fileStruct = FileStruct::fromUploadedFile($file);
+
+        $resourceType = $this->isEncryptedPdf($file) ? 'raw' : 'auto';
         $resourceStruct = new ResourceStruct(
             $fileStruct,
-            'auto',
+            $resourceType,
             $folder,
             $visibility,
             $request->request->get('filename'),
@@ -112,5 +124,37 @@ final class Upload extends AbstractController
         }
 
         return new JsonResponse($this->formatResource($resource), $httpCode);
+    }
+
+    private function isEncryptedPdf(UploadedFile $file): bool
+    {
+        if (strtolower((string) $file->getClientOriginalExtension()) !== 'pdf') {
+            return false;
+        }
+
+        $path = (string) $file->getRealPath();
+        if ($path === '' || !is_file($path) || !is_readable($path)) {
+            return false;
+        }
+
+        $fp = @fopen($path, 'r');
+        if ($fp === false) {
+            return false;
+        }
+
+        $head = (string) fread($fp, 4096);
+
+        // Encryption marker may be located anywhere; read also from the end.
+        // Suppress fseek errors (e.g. very small files).
+        @fseek($fp, -16384, SEEK_END);
+        $tail = (string) fread($fp, 16384);
+
+        fclose($fp);
+
+        if (strpos($head, '%PDF-') !== 0) {
+            return false;
+        }
+
+        return strpos($head . $tail, '/Encrypt') !== false;
     }
 }

--- a/bundle/Controller/Resource/Upload.php
+++ b/bundle/Controller/Resource/Upload.php
@@ -27,8 +27,12 @@ use function in_array;
 use function is_array;
 use function is_file;
 use function is_readable;
+use function filesize;
+use function preg_match;
+use function strrpos;
 use function strpos;
 use function strtolower;
+use function substr;
 
 use const SEEK_END;
 
@@ -142,17 +146,36 @@ final class Upload extends AbstractController
             return false;
         }
 
-        $head = (string) fread($fp, 4096);
+        $fileSize = filesize($path);
 
-        @fseek($fp, -16384, SEEK_END);
-        $tail = (string) fread($fp, 16384);
+        // For small PDFs, `head` and `tail` reads can overlap and even fully duplicate the file contents.
+        // This can re-introduce false positives (e.g. `/Encrypt` in a trailing comment after `%%EOF`).
+        // In that case, scan the full content once.
+        if ($fileSize !== false && $fileSize <= 20480) {
+            $content = (string) fread($fp, $fileSize);
+        } else {
+            $head = (string) fread($fp, 4096);
+
+            @fseek($fp, -16384, SEEK_END);
+            $tail = (string) fread($fp, 16384);
+
+            $content = $head . $tail;
+        }
 
         fclose($fp);
 
-        if (strpos($head, '%PDF-') !== 0) {
+        if (strpos($content, '%PDF-') !== 0) {
             return false;
         }
 
-        return strpos($head . $tail, '/Encrypt') !== false;
+        // Ignore anything after the last EOF marker (some tools append non-PDF comments/metadata).
+        $eofPos = strrpos($content, '%%EOF');
+        if ($eofPos !== false) {
+            $content = substr($content, 0, $eofPos + 5);
+        }
+
+        // Detect presence of encryption dictionary reference in PDF object context.
+        // This avoids false positives where `/Encrypt` appears in metadata or trailing comments.
+        return (bool) preg_match('/\/(?:Encrypt)\s+(\d+|<<)/m', $content);
     }
 }

--- a/bundle/Controller/Resource/Upload.php
+++ b/bundle/Controller/Resource/Upload.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 use function fclose;
+use function filesize;
 use function fopen;
 use function fread;
 use function fseek;
@@ -27,10 +28,9 @@ use function in_array;
 use function is_array;
 use function is_file;
 use function is_readable;
-use function filesize;
 use function preg_match;
-use function strrpos;
 use function strpos;
+use function strrpos;
 use function strtolower;
 use function substr;
 
@@ -148,9 +148,6 @@ final class Upload extends AbstractController
 
         $fileSize = filesize($path);
 
-        // For small PDFs, `head` and `tail` reads can overlap and even fully duplicate the file contents.
-        // This can re-introduce false positives (e.g. `/Encrypt` in a trailing comment after `%%EOF`).
-        // In that case, scan the full content once.
         if ($fileSize !== false && $fileSize <= 20480) {
             $content = (string) fread($fp, $fileSize);
         } else {
@@ -168,14 +165,11 @@ final class Upload extends AbstractController
             return false;
         }
 
-        // Ignore anything after the last EOF marker (some tools append non-PDF comments/metadata).
         $eofPos = strrpos($content, '%%EOF');
         if ($eofPos !== false) {
             $content = substr($content, 0, $eofPos + 5);
         }
 
-        // Detect presence of encryption dictionary reference in PDF object context.
-        // This avoids false positives where `/Encrypt` appears in metadata or trailing comments.
         return (bool) preg_match('/\/(?:Encrypt)\s+(\d+|<<)/m', $content);
     }
 }

--- a/tests/bundle/Controller/Resource/UploadTest.php
+++ b/tests/bundle/Controller/Resource/UploadTest.php
@@ -275,9 +275,9 @@ final class UploadTest extends TestCase
         $tmpPdfPath = (string) tempnam(sys_get_temp_dir(), 'ngrm_unencrypted_pdf_metadata_');
         file_put_contents(
             $tmpPdfPath,
-            "%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n" .
-            "/Title (/Encrypt)\n" .
-            "%%EOF\n",
+            "%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+            . "/Title (/Encrypt)\n"
+            . "%%EOF\n",
         );
 
         $request = new Request();
@@ -361,9 +361,9 @@ final class UploadTest extends TestCase
         $tmpPdfPath = (string) tempnam(sys_get_temp_dir(), 'ngrm_unencrypted_pdf_comment_');
         file_put_contents(
             $tmpPdfPath,
-            "%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n" .
-            "%%EOF\n" .
-            "% /Encrypt 2 0 R\n",
+            "%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+            . "%%EOF\n"
+            . "% /Encrypt 2 0 R\n",
         );
 
         $request = new Request();

--- a/tests/bundle/Controller/Resource/UploadTest.php
+++ b/tests/bundle/Controller/Resource/UploadTest.php
@@ -27,7 +27,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+use function file_put_contents;
 use function json_encode;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
 
 #[CoversClass(UploadController::class)]
 #[CoversClass(AbstractController::class)]
@@ -78,7 +82,7 @@ final class UploadTest extends TestCase
             ->willReturn('sample_image');
 
         $uploadedFileMock
-            ->expects(self::exactly(2))
+            ->expects(self::exactly(3))
             ->method('getClientOriginalExtension')
             ->willReturn('jpg');
 
@@ -179,6 +183,93 @@ final class UploadTest extends TestCase
         );
     }
 
+    public function testUploadEncryptedPdfIsRaw(): void
+    {
+        $tmpPdfPath = (string) tempnam(sys_get_temp_dir(), 'ngrm_encrypted_pdf_');
+        file_put_contents($tmpPdfPath, "%PDF-1.7\n1 0 obj\n<< /Encrypt 2 0 R >>\nendobj\n");
+
+        $request = new Request();
+        $request->request->add([
+            'folder' => 'media/document',
+        ]);
+
+        $uploadedFileMock = $this->createMock(UploadedFile::class);
+
+        $uploadedFileMock
+            ->expects(self::once())
+            ->method('isFile')
+            ->willReturn(true);
+
+        // getRealPath is used for md5 hash + FileStruct + encryption detector
+        $uploadedFileMock
+            ->expects(self::exactly(4))
+            ->method('getRealPath')
+            ->willReturn($tmpPdfPath);
+
+        $uploadedFileMock
+            ->expects(self::exactly(2))
+            ->method('getClientOriginalName')
+            ->willReturn('protected.pdf');
+
+        // getClientOriginalExtension is used for FileStruct + encryption detector
+        $uploadedFileMock
+            ->expects(self::exactly(3))
+            ->method('getClientOriginalExtension')
+            ->willReturn('pdf');
+
+        $request->files->add([
+            'file' => $uploadedFileMock,
+        ]);
+
+        $this->fileHashFactoryMock
+            ->expects(self::once())
+            ->method('createHash')
+            ->with($tmpPdfPath)
+            ->willReturn('md5hash');
+
+        $fileStruct = FileStruct::fromUploadedFile($uploadedFileMock);
+
+        $resourceStruct = new ResourceStruct(
+            $fileStruct,
+            'raw',
+            Folder::fromPath('media/document'),
+            'public',
+            $request->request->get('filename'),
+        );
+
+        $resource = new RemoteResource(
+            remoteId: 'upload|raw|media/document/protected.pdf',
+            type: 'raw',
+            url: 'https://cloudinary.com/test/upload/raw/media/document/protected.pdf',
+            md5: 'md5hash',
+            name: 'protected.pdf',
+            folder: Folder::fromPath('media/document'),
+            size: 123,
+        );
+
+        $this->providerMock
+            ->expects(self::once())
+            ->method('upload')
+            ->with($resourceStruct)
+            ->willReturn($resource);
+
+        $this->providerMock
+            ->expects(self::exactly(0))
+            ->method('buildVariation')
+            ->willReturnCallback(
+                static fn () => new RemoteResourceVariation(
+                    $resource,
+                    'https://cloudinary.com/test/variation/url',
+                ),
+            );
+
+        $response = $this->controller->__invoke($request);
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+
+        unlink($tmpPdfPath);
+    }
+
     public function testUploadProtectedWithContext(): void
     {
         $uploadContext = [
@@ -211,7 +302,7 @@ final class UploadTest extends TestCase
             ->willReturn('sample_image');
 
         $uploadedFileMock
-            ->expects(self::exactly(2))
+            ->expects(self::exactly(3))
             ->method('getClientOriginalExtension')
             ->willReturn('jpg');
 
@@ -396,7 +487,7 @@ final class UploadTest extends TestCase
             ->willReturn('sample_image');
 
         $uploadedFileMock
-            ->expects(self::exactly(2))
+            ->expects(self::exactly(3))
             ->method('getClientOriginalExtension')
             ->willReturn('jpg');
 
@@ -555,7 +646,7 @@ final class UploadTest extends TestCase
             ->willReturn('sample_image');
 
         $uploadedFileMock
-            ->expects(self::exactly(2))
+            ->expects(self::exactly(3))
             ->method('getClientOriginalExtension')
             ->willReturn('jpg');
 

--- a/tests/bundle/Controller/Resource/UploadTest.php
+++ b/tests/bundle/Controller/Resource/UploadTest.php
@@ -270,6 +270,178 @@ final class UploadTest extends TestCase
         unlink($tmpPdfPath);
     }
 
+    public function testUploadPdfWithEncryptInMetadataIsAuto(): void
+    {
+        $tmpPdfPath = (string) tempnam(sys_get_temp_dir(), 'ngrm_unencrypted_pdf_metadata_');
+        file_put_contents(
+            $tmpPdfPath,
+            "%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n" .
+            "/Title (/Encrypt)\n" .
+            "%%EOF\n",
+        );
+
+        $request = new Request();
+        $request->request->add([
+            'folder' => 'media/document',
+        ]);
+
+        $uploadedFileMock = $this->createMock(UploadedFile::class);
+
+        $uploadedFileMock
+            ->expects(self::once())
+            ->method('isFile')
+            ->willReturn(true);
+
+        // getRealPath is used for md5 hash + FileStruct + encryption detector
+        $uploadedFileMock
+            ->expects(self::exactly(4))
+            ->method('getRealPath')
+            ->willReturn($tmpPdfPath);
+
+        $uploadedFileMock
+            ->expects(self::exactly(2))
+            ->method('getClientOriginalName')
+            ->willReturn('unencrypted.pdf');
+
+        // getClientOriginalExtension is used for FileStruct + encryption detector
+        $uploadedFileMock
+            ->expects(self::exactly(3))
+            ->method('getClientOriginalExtension')
+            ->willReturn('pdf');
+
+        $request->files->add([
+            'file' => $uploadedFileMock,
+        ]);
+
+        $this->fileHashFactoryMock
+            ->expects(self::once())
+            ->method('createHash')
+            ->with($tmpPdfPath)
+            ->willReturn('md5hash');
+
+        $fileStruct = FileStruct::fromUploadedFile($uploadedFileMock);
+
+        $resourceStruct = new ResourceStruct(
+            $fileStruct,
+            'auto',
+            Folder::fromPath('media/document'),
+            'public',
+            $request->request->get('filename'),
+        );
+
+        $resource = new RemoteResource(
+            remoteId: 'upload|auto|media/document/unencrypted.pdf',
+            type: 'auto',
+            url: 'https://cloudinary.com/test/upload/auto/media/document/unencrypted.pdf',
+            md5: 'md5hash',
+            name: 'unencrypted.pdf',
+            folder: Folder::fromPath('media/document'),
+            size: 123,
+        );
+
+        $this->providerMock
+            ->expects(self::once())
+            ->method('upload')
+            ->with($resourceStruct)
+            ->willReturn($resource);
+
+        $this->providerMock
+            ->expects(self::exactly(0))
+            ->method('buildVariation');
+
+        $response = $this->controller->__invoke($request);
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+
+        unlink($tmpPdfPath);
+    }
+
+    public function testUploadPdfWithEncryptInTrailingCommentAfterEofIsAuto(): void
+    {
+        $tmpPdfPath = (string) tempnam(sys_get_temp_dir(), 'ngrm_unencrypted_pdf_comment_');
+        file_put_contents(
+            $tmpPdfPath,
+            "%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n" .
+            "%%EOF\n" .
+            "% /Encrypt 2 0 R\n",
+        );
+
+        $request = new Request();
+        $request->request->add([
+            'folder' => 'media/document',
+        ]);
+
+        $uploadedFileMock = $this->createMock(UploadedFile::class);
+
+        $uploadedFileMock
+            ->expects(self::once())
+            ->method('isFile')
+            ->willReturn(true);
+
+        // getRealPath is used for md5 hash + FileStruct + encryption detector
+        $uploadedFileMock
+            ->expects(self::exactly(4))
+            ->method('getRealPath')
+            ->willReturn($tmpPdfPath);
+
+        $uploadedFileMock
+            ->expects(self::exactly(2))
+            ->method('getClientOriginalName')
+            ->willReturn('unencrypted.pdf');
+
+        // getClientOriginalExtension is used for FileStruct + encryption detector
+        $uploadedFileMock
+            ->expects(self::exactly(3))
+            ->method('getClientOriginalExtension')
+            ->willReturn('pdf');
+
+        $request->files->add([
+            'file' => $uploadedFileMock,
+        ]);
+
+        $this->fileHashFactoryMock
+            ->expects(self::once())
+            ->method('createHash')
+            ->with($tmpPdfPath)
+            ->willReturn('md5hash');
+
+        $fileStruct = FileStruct::fromUploadedFile($uploadedFileMock);
+
+        $resourceStruct = new ResourceStruct(
+            $fileStruct,
+            'auto',
+            Folder::fromPath('media/document'),
+            'public',
+            $request->request->get('filename'),
+        );
+
+        $resource = new RemoteResource(
+            remoteId: 'upload|auto|media/document/unencrypted.pdf',
+            type: 'auto',
+            url: 'https://cloudinary.com/test/upload/auto/media/document/unencrypted.pdf',
+            md5: 'md5hash',
+            name: 'unencrypted.pdf',
+            folder: Folder::fromPath('media/document'),
+            size: 123,
+        );
+
+        $this->providerMock
+            ->expects(self::once())
+            ->method('upload')
+            ->with($resourceStruct)
+            ->willReturn($resource);
+
+        $this->providerMock
+            ->expects(self::exactly(0))
+            ->method('buildVariation');
+
+        $response = $this->controller->__invoke($request);
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+
+        unlink($tmpPdfPath);
+    }
+
     public function testUploadProtectedWithContext(): void
     {
         $uploadContext = [


### PR DESCRIPTION
The function first checks the file extension. If it's not a .pdf (case-insensitive), it returns false immediately. This avoids unnecessary file reading for images or other documents. After that, it ensures the temporary file uploaded by Symfony actually exists on the disk and is readable by the PHP process.
For small PDFs, `head` and `tail` reads can overlap and even fully duplicate the file contents.
This can re-introduce false positives (e.g. `/Encrypt` in a trailing comment after `%%EOF`), in that case, we scan the full content once.

`if ($fileSize !== false && $fileSize <= 20480) {
            $content = (string) fread($fp, $fileSize);
        } else {
            $head = (string) fread($fp, 4096);

            @fseek($fp, -16384, SEEK_END);
            $tail = (string) fread($fp, 16384);

            $content = $head . $tail;
        }`

Otherwise, nstead of loading the entire PDF into memory (which could be hundreds of megabytes), the function reads only the specific parts of the file where encryption markers are typically stored:
The Head (first 4KB):
`$head = (string) fread($fp, 4096);`
This captures the PDF header and initial metadata.

We ignore anything after the last EOF marker (some tools append non-PDF comments/metadata).
`$eofPos = strrpos($content, '%%EOF');
        if ($eofPos !== false) {
            $content = substr($content, 0, $eofPos + 5);
        }`

Finally, we detect presence of encryption dictionary reference in PDF object context.
This avoids false positives where `/Encrypt` appears in metadata or trailing comments.
`return (bool) preg_match('/\/(?:Encrypt)\s+(\d+|<<)/m', $content);`

This is the core logic. It searches for the /Encrypt token within the combined head and tail buffers.
In the PDF specification, the /Encrypt key in the document trailer dictionary indicates that the file is encrypted (password-protected).
If this token is found, the function returns true, signaling the controller to use resourceType: 'raw' for the Cloudinary upload.


